### PR TITLE
removing the call of 'scralling(0)' from onScrollStateChanged from  C…

### DIFF
--- a/carouselview/src/main/java/alirezat775/lib/carouselview/CarouselView.kt
+++ b/carouselview/src/main/java/alirezat775/lib/carouselview/CarouselView.kt
@@ -211,7 +211,6 @@ class CarouselView
     override fun onScrollStateChanged(state: Int) {
         super.onScrollStateChanged(state)
         if (state == SCROLL_STATE_IDLE) {
-            scrolling(0)
             if (isAutoScroll) {
                 getScheduler()?.start()
             }


### PR DESCRIPTION
…arouselView.kt. This line is causin the logcat going mad and saying 'Smooth Scroll action is being updated too frequently. Make sure you are not changing it unless necessary'; this issue has already been reported 10 days ago by another user

see https://github.com/alirezat775/carousel-view/issues/12